### PR TITLE
Don't include a static image in the camera motion slack notifications

### DIFF
--- a/automation/log_camera_motion_events_to_slack.yaml
+++ b/automation/log_camera_motion_events_to_slack.yaml
@@ -23,5 +23,3 @@ action:
         - title: '{{ trigger.to_state.attributes.friendly_name | capitalize }}'
           title_link: |
             {{ states.weblink.self.state }}{{ states.camera[(trigger.to_state.attributes.friendly_name|replace(" ", "_"))].attributes.entity_picture | replace("proxy", "proxy_stream") }}
-          image_url: |
-            {{ states.weblink.self.state }}{{ states.camera[(trigger.to_state.attributes.friendly_name|replace(" ", "_"))].attributes.entity_picture }}


### PR DESCRIPTION
This may fix https://github.com/jnewland/ha-config/issues/3? Gonna deploy and watch the memory usage graphs for a few hours. If memory usage remains stable, I'll report a leak upstream.