### PR TITLE
Add script to update my home-assistant fork

### DIFF
--- a/script/update-ha
+++ b/script/update-ha
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Updates my fork of HA
 set -ex
 cd ~/src/home-assistant
 
@@ -7,6 +8,15 @@ if [ -n "$(git status --porcelain)" ]; then
   exit 1
 fi
 
+if [ "$1" = "--force" ]; then
+  git checkout rancho-de-newland
+  git merge dev
+  git push jnewland :dev
+  git branch -d dev
+  git push jnewland rancho-de-newland
+fi
+
+git branch dev || true
 git checkout dev
 git pull jnewland dev || true
 git pull origin dev
@@ -15,3 +25,5 @@ git push jnewland dev
 open "https://github.com/jnewland/home-assistant/compare/jnewland:rancho-de-newland...jnewland:dev"
 
 git checkout -
+
+echo "Run again --force merge dev into rancho-de-newland, push, and cleanup."

--- a/script/update-ha
+++ b/script/update-ha
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -ex
+cd ~/src/home-assistant
+
+if [ -n "$(git status --porcelain)" ]; then
+  git status --porcelain
+  exit 1
+fi
+
+git checkout dev
+git pull jnewland dev || true
+git pull origin dev
+git push jnewland dev
+
+open "https://github.com/jnewland/home-assistant/compare/jnewland:rancho-de-newland...jnewland:dev"
+
+git checkout -


### PR DESCRIPTION
I run my home-assistant install off of the `rancho-de-newland` branch of https://github.com/jnewland/home-assistant. This PR adds a tiny bash script to automate the process of updating that from the latest from the `dev` branch. Once everything's updated https://github.com/jnewland/home-assistant/compare/jnewland:rancho-de-newland...jnewland:dev is opened in my browser for easy code review with a big green button to create a PR if necessary. If no PR is necessary, running the command again with `--force` updates and cleans up.