### PR TITLE
Fix binary sensors

### DIFF
--- a/binary_sensor.yaml
+++ b/binary_sensor.yaml
@@ -4,9 +4,6 @@
   value_template: '{{ value_json < 60}}'
 - platform: template
   sensors:
-    together:
-      value_template: |
-        {{ distance(states.device_tracker.jphone_jphone, states.device_tracker.kphone_kphone) < 0.25 }}
     rain_today:
       value_template: |
         {{
@@ -14,3 +11,8 @@
           float(states.sensor.dark_sky_precip_probability.state) > 0 or
           float(states.sensor.dark_sky_precip_intensity.state) > 0
         }}
+- platform: template
+  sensors:
+    together:
+      value_template: |
+        {{ distance(states.device_tracker.jphone_jphone, states.device_tracker.kphone_kphone) < 0.25 }}

--- a/binary_sensor.yaml
+++ b/binary_sensor.yaml
@@ -5,7 +5,8 @@
 - platform: template
   sensors:
     together:
-      value_template: {{ distance(states.device_tracker.jphone_jphone, states.device_tracker.kphone_kphone) < 0.25 }}
+      value_template: |
+        {{ distance(states.device_tracker.jphone_jphone, states.device_tracker.kphone_kphone) < 0.25 }}
     rain_today:
       value_template: |
         {{

--- a/binary_sensor.yaml
+++ b/binary_sensor.yaml
@@ -4,6 +4,8 @@
   value_template: '{{ value_json < 60}}'
 - platform: template
   sensors:
+    together:
+      value_template: {{ distance(states.device_tracker.jphone_jphone, states.device_tracker.kphone_kphone) < 0.25 }}
     rain_today:
       value_template: |
         {{
@@ -11,6 +13,3 @@
           float(states.sensor.dark_sky_precip_probability.state) > 0 or
           float(states.sensor.dark_sky_precip_intensity.state) > 0
         }}
-    together:
-      value_template: |
-        {{ distance(states.device_tracker.jphone_jphone, states.device_tracker.kphone_kphone) < 0.25 }}

--- a/binary_sensor.yaml
+++ b/binary_sensor.yaml
@@ -11,8 +11,6 @@
           float(states.sensor.dark_sky_precip_probability.state) > 0 or
           float(states.sensor.dark_sky_precip_intensity.state) > 0
         }}
-- platform: template
-  sensors:
     together:
       value_template: |
         {{

--- a/binary_sensor.yaml
+++ b/binary_sensor.yaml
@@ -15,4 +15,7 @@
   sensors:
     together:
       value_template: |
-        {{ distance(states.device_tracker.jphone_jphone, states.device_tracker.kphone_kphone) < 0.25 }}
+        {{
+          distance(states.device_tracker.jphone_jphone, states.device_tracker.kphone_kphone) != None and
+          distance(states.device_tracker.jphone_jphone, states.device_tracker.kphone_kphone) < 0.25
+        }}


### PR DESCRIPTION
I guess `distance` can return a NoneType during the first run, and an exception during the first run prevents any subsequent refreshes.