### PR TITLE
Use a more explicit time trigger

### DIFF
--- a/automation/early_riser.yaml
+++ b/automation/early_riser.yaml
@@ -10,9 +10,8 @@ trigger:
 condition:
   condition: and
   conditions:
-  - condition: sun
-    after: sunrise
-    after_offset: '-1:00:00'
+  - condition: time
+    after: '05:00:00'
   - condition: template
     value_template: '{{
                       states.input_select.mode.state != "Pause" and


### PR DESCRIPTION
The sunsrise trigger is super confusing to reason about. This one makes sense: if there's motion in the bathroom after 5am, it assumes we've woken up. If it's before 5am, and we're sleeping, the nighlight comes on and nothing else happens.