### PR TITLE
New speaker setup

### DIFF
--- a/automation/log_state_changes_to_slack.yaml
+++ b/automation/log_state_changes_to_slack.yaml
@@ -24,10 +24,10 @@ trigger:
     - input_select.mode
     - lock.front_door_12
     - media_player.itunes
-    - media_player.atrium_wall_speakers
+    - media_player.atrium_speakers
     - media_player.kitchen_speakers
     - media_player.living_front_speakers
-    - media_player.living_rear_speakers
+    - media_player.patio_speakers
     - media_player.master_bathroom_speakers
     - media_player.master_bedroom_speakers
     - media_player.office_tv

--- a/customize/media_players.yaml
+++ b/customize/media_players.yaml
@@ -1,2 +1,0 @@
-media_player.bedroom_tv:
-  emulated_hue: true

--- a/groups/atrium.yaml
+++ b/groups/atrium.yaml
@@ -3,5 +3,5 @@ view: true
 icon: mdi:tree
 entities:
 - group.outdoor
-- media_player.atrium_wall_speakers
+- media_player.atrium_speakers
 - group.gates

--- a/groups/downstairs.yaml
+++ b/groups/downstairs.yaml
@@ -3,6 +3,5 @@
 - group.great_room
 - group.hall
 - group.office
-- media_player.living_front_speakers
-- media_player.living_rear_speakers
+- media_player.living_speakers
 - media_player.kitchen_speakers

--- a/groups/downstairs_non_guest.yaml
+++ b/groups/downstairs_non_guest.yaml
@@ -2,6 +2,5 @@
 - group.great_room
 - group.hall
 - group.office
-- media_player.living_front_speakers
-- media_player.living_rear_speakers
+- media_player.living_speakers
 - media_player.kitchen_speakers

--- a/groups/great_room_speakers.yaml
+++ b/groups/great_room_speakers.yaml
@@ -1,6 +1,5 @@
 ---
 entities:
-- media_player.living_front_speakers
-- media_player.living_rear_speakers
+- media_player.living_speakers
 - media_player.kitchen_speakers
-- media_player.atrium_wall_speakers
+- media_player.atrium_speakers

--- a/groups/speakers.yaml
+++ b/groups/speakers.yaml
@@ -2,9 +2,9 @@
 view: true
 icon: mdi:speaker
 entities:
-- media_player.living_front_speakers
-- media_player.living_rear_speakers
+- media_player.living_speakers
+- media_player.patio_speakers
 - media_player.kitchen_speakers
-- media_player.atrium_wall_speakers
+- media_player.atrium_speakers
 - media_player.master_bedroom_speakers
 - media_player.master_bathroom_speakers

--- a/media_player.yaml
+++ b/media_player.yaml
@@ -1,20 +1,21 @@
+# Powered sub is attached to this zone's preamp out
 - platform: mpr_6zhmaut
-  name: living front speakers
+  name: living speakers
   host: !env_var MPR_API_IP
   port: !env_var MPR_API_PORT
   zone: 11
 - platform: mpr_6zhmaut
-  name: living rear speakers
+  name: kitchen speakers
   host: !env_var MPR_API_IP
   port: !env_var MPR_API_PORT
   zone: 12
 - platform: mpr_6zhmaut
-  name: kitchen speakers
+  name: patio speakers
   host: !env_var MPR_API_IP
   port: !env_var MPR_API_PORT
   zone: 13
 - platform: mpr_6zhmaut
-  name: atrium wall speakers
+  name: atrium speakers
   host: !env_var MPR_API_IP
   port: !env_var MPR_API_PORT
   zone: 14

--- a/scenes/reading_with_guests_present.yaml
+++ b/scenes/reading_with_guests_present.yaml
@@ -15,5 +15,5 @@ entities:
     state: 'on'
   media_player.master_bathroom_speakers:
     state: 'on'
-  media_player.atrium_wall_speakers:
+  media_player.atrium_speakers:
     state: 'off'

--- a/scenes/reading_without_guests_present.yaml
+++ b/scenes/reading_without_guests_present.yaml
@@ -15,7 +15,9 @@ entities:
     state: 'on'
   media_player.master_bathroom_speakers:
     state: 'on'
-  media_player.atrium_wall_speakers:
+  media_player.atrium_speakers:
+    state: 'off'
+  media_player.patio_speakers:
     state: 'off'
   alarm_control_panel.alarm:
     state: armed_home

--- a/scenes/speakers_all.yaml
+++ b/scenes/speakers_all.yaml
@@ -1,12 +1,12 @@
 name: 'Speakers All'
 entities:
-  media_player.living_front_speakers:
+  media_player.living_speakers:
     state: 'on'
-  media_player.living_rear_speakers:
+  media_player.patio_speakers:
     state: 'on'
   media_player.kitchen_speakers:
     state: 'on'
-  media_player.atrium_wall_speakers:
+  media_player.atrium_speakers:
     state: 'on'
   media_player.master_bedroom_speakers:
     state: 'on'

--- a/scenes/speakers_downstairs.yaml
+++ b/scenes/speakers_downstairs.yaml
@@ -1,12 +1,12 @@
 name: 'Speakers Downstairs'
 entities:
-  media_player.living_front_speakers:
-    state: 'on'
-  media_player.living_rear_speakers:
+  media_player.living_speakers:
     state: 'on'
   media_player.kitchen_speakers:
     state: 'on'
-  media_player.atrium_wall_speakers:
+  media_player.atrium_speakers:
+    state: 'off'
+  media_player.patio_speakers:
     state: 'off'
   media_player.master_bedroom_speakers:
     state: 'off'

--- a/scenes/speakers_indoor.yaml
+++ b/scenes/speakers_indoor.yaml
@@ -1,12 +1,12 @@
 name: 'Speakers Indoor'
 entities:
-  media_player.living_front_speakers:
-    state: 'on'
-  media_player.living_rear_speakers:
+  media_player.living_speakers:
     state: 'on'
   media_player.kitchen_speakers:
     state: 'on'
-  media_player.atrium_wall_speakers:
+  media_player.patio_speakers:
+    state: 'off'
+  media_player.atrium_speakers:
     state: 'off'
   media_player.master_bedroom_speakers:
     state: 'on'

--- a/scenes/speakers_outdoor.yaml
+++ b/scenes/speakers_outdoor.yaml
@@ -1,13 +1,13 @@
 name: 'Speakers Outdoor'
 entities:
-  media_player.living_front_speakers:
-    state: 'off'
-  media_player.living_rear_speakers:
+  media_player.patio_speakers:
+    state: 'on'
+  media_player.atrium_speakers:
+    state: 'on'
+  media_player.living_speakers:
     state: 'off'
   media_player.kitchen_speakers:
     state: 'off'
-  media_player.atrium_wall_speakers:
-    state: 'on'
   media_player.master_bedroom_speakers:
     state: 'off'
   media_player.master_bathroom_speakers:

--- a/scenes/speakers_upstairs.yaml
+++ b/scenes/speakers_upstairs.yaml
@@ -1,14 +1,14 @@
 name: 'Speakers Upstairs'
 entities:
-  media_player.living_front_speakers:
-    state: 'off'
-  media_player.living_rear_speakers:
-    state: 'off'
-  media_player.kitchen_speakers:
-    state: 'off'
-  media_player.atrium_wall_speakers:
-    state: 'off'
   media_player.master_bedroom_speakers:
     state: 'on'
   media_player.master_bathroom_speakers:
     state: 'on'
+  media_player.living_speakers:
+    state: 'off'
+  media_player.patio_speakers:
+    state: 'off'
+  media_player.kitchen_speakers:
+    state: 'off'
+  media_player.atrium_speakers:
+    state: 'off'

--- a/scripts/mode_cooking.yaml
+++ b/scripts/mode_cooking.yaml
@@ -8,8 +8,7 @@ sequence:
       - light.pendants_51
   - service: media_player.turn_on
     entity_id:
-      - media_player.living_front_speakers
-      - media_player.living_rear_speakers
+      - media_player.living_speakers
       - media_player.kitchen_speakers
   - service: input_select.select_option
     entity_id: input_select.mode

--- a/scripts/mode_morning.yaml
+++ b/scripts/mode_morning.yaml
@@ -12,8 +12,7 @@ sequence:
       - media_player.master_bathroom_speakers
   - service: media_player.turn_on
     entity_id:
-      - media_player.living_front_speakers
-      - media_player.living_rear_speakers
+      - media_player.living_speakers
       - media_player.kitchen_speakers
   - service: alarm_control_panel.alarm_disarm
     entity_id: alarm_control_panel.alarm


### PR DESCRIPTION
Front and rear living speakers have been wired in parallel, and the patio speakers moved into one of the now-freed zones. This updates the media player entities and related automation to match.