### PR TITLE
Don't turn off the TV when we ask the house to stop

### DIFF
--- a/scripts/quiet.yaml
+++ b/scripts/quiet.yaml
@@ -2,7 +2,6 @@ sequence:
   - service: homeassistant.turn_off
     entity_id:
       - group.speakers
-      - media_player.office_tv
       - group.airplay
   - service: media_player.media_pause
     entity_id: media_player.itunes


### PR DESCRIPTION
It takes a few minutes for it to be able to turned on again by the Apple TV remote, which can be annoying. Saying "alexa, ask the house to stop" still stops any playing music and turns off the house speakers.

/cc @katienewland