### PR TITLE
Add yamburger configuration

### DIFF
--- a/.github/yamburger.yaml
+++ b/.github/yamburger.yaml
@@ -1,0 +1,15 @@
+tags:
+- name: env_var
+  kind: scalar
+- name: include
+  kind: scalar
+- name: secret
+  kind: scalar
+- name: include_dir_list
+  kind: scalar
+- name: include_dir_merge_list
+  kind: scalar
+- name: include_dir_named
+  kind: scalar
+- name: include_dir_merge_named
+  kind: scalar


### PR DESCRIPTION
This PR adds [YAMBURGER](https://github.com/urcomputeringpal/yamburger) configuration for Home Assistant's custom YAML tags.