### PR TITLE
Push camera snapshots to slack on an interval

### DIFF
--- a/automation/camera_snaps.yaml
+++ b/automation/camera_snaps.yaml
@@ -1,0 +1,30 @@
+alias: Camera snaps
+trigger:
+  platform: time_pattern
+  # Every hour
+  minutes: 0
+action:
+  - service: notify.slack
+    data_template:
+      message: "Debug: {{ states.camera.front_yard_left.attributes.entity_picture }}"
+  # - service: notify.slack
+  #   data_template:
+  #     message: ":camera_with_flash:"
+  #     data:
+  #       attachments:
+  #       - title: Front yard left
+  #         image_url: "https://home.jnewland.com/{{ states.camera.front_yard_left.attributes.entity_picture }}"
+  # - service: notify.slack
+  #   data_template:
+  #     message: ":camera_with_flash:"
+  #     data:
+  #       attachments:
+  #       - title: Back porch fountain
+  #         image_url: "https://home.jnewland.com/{{ states.camera.back_porch_fountain.attributes.entity_picture }}"
+  # - service: notify.slack
+  #   data_template:
+  #     message: ":camera_with_flash:"
+  #     data:
+  #       attachments:
+  #       - title: Atrium
+  #         image_url: "https://home.jnewland.com/{{ states.camera.atrium.attributes.entity_picture }}"

--- a/automation/camera_snaps.yaml
+++ b/automation/camera_snaps.yaml
@@ -5,8 +5,11 @@ trigger:
   minutes: 0
 action:
   - service: script.notify_slack_about_camera
-    entity_id: camera.front_yard_left
+    data:
+      entity_id: camera.front_yard_left
   - service: script.notify_slack_about_camera
-    entity_id: camera.back_porch_fountain
+    data:
+      entity_id: camera.back_porch_fountain
   - service: script.notify_slack_about_camera
-    entity_id: camera.atrium
+    data:
+      entity_id: camera.atrium

--- a/automation/camera_snaps.yaml
+++ b/automation/camera_snaps.yaml
@@ -4,27 +4,9 @@ trigger:
   # Every hour
   minutes: 0
 action:
-  - service: notify.slack
-    data_template:
-      message: "Debug: {{ states.camera.front_yard_left.attributes.entity_picture }}"
-  # - service: notify.slack
-  #   data_template:
-  #     message: ":camera_with_flash:"
-  #     data:
-  #       attachments:
-  #       - title: Front yard left
-  #         image_url: "https://home.jnewland.com/{{ states.camera.front_yard_left.attributes.entity_picture }}"
-  # - service: notify.slack
-  #   data_template:
-  #     message: ":camera_with_flash:"
-  #     data:
-  #       attachments:
-  #       - title: Back porch fountain
-  #         image_url: "https://home.jnewland.com/{{ states.camera.back_porch_fountain.attributes.entity_picture }}"
-  # - service: notify.slack
-  #   data_template:
-  #     message: ":camera_with_flash:"
-  #     data:
-  #       attachments:
-  #       - title: Atrium
-  #         image_url: "https://home.jnewland.com/{{ states.camera.atrium.attributes.entity_picture }}"
+  - service: script.notify_slack_about_camera
+    entity_id: camera.front_yard_left
+  - service: script.notify_slack_about_camera
+    entity_id: camera.back_porch_fountain
+  - service: script.notify_slack_about_camera
+    entity_id: camera.atrium

--- a/automation/camera_snaps.yaml
+++ b/automation/camera_snaps.yaml
@@ -1,8 +1,8 @@
 alias: Camera snaps
 trigger:
   platform: time_pattern
-  # Every hour
-  minutes: 0
+  hours: "/4"
+  minutes: "0"
 action:
   - service: script.notify_slack_about_camera
     data:

--- a/automation/camera_snaps.yaml
+++ b/automation/camera_snaps.yaml
@@ -3,6 +3,10 @@ trigger:
   platform: time_pattern
   hours: "/4"
   minutes: "0"
+condition:
+  condition: state
+  entity_id: input_select.mode
+  state: Away
 action:
   - service: script.notify_slack_about_camera
     data:

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -8,6 +8,8 @@ homeassistant:
   customize: !include_dir_merge_named customize
   packages: !include_dir_named packages
   auth_providers: !include auth_providers.yaml
+  whitelist_external_dirs:
+    - /tmp
 
 default_config:
 
@@ -55,7 +57,5 @@ vera: !include vera.yaml
 weather:
   - platform: darksky
     api_key: !env_var FORECAST_API_KEY
-whitelist_external_dirs:
-  - /tmp
 zone: !include zone.yaml
 vacuum: !include_dir_list vacuums

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -55,5 +55,7 @@ vera: !include vera.yaml
 weather:
   - platform: darksky
     api_key: !env_var FORECAST_API_KEY
+whitelist_external_dirs:
+  - /tmp
 zone: !include zone.yaml
 vacuum: !include_dir_list vacuums

--- a/scripts/notify_slack_about_camera.yaml
+++ b/scripts/notify_slack_about_camera.yaml
@@ -7,7 +7,8 @@ sequence:
         /tmp/slack_{{ entity_id.split('.')[1] }}.png
   - service: notify.slack
     data_template:
-      message: ":camera_with_flash: {{ entity_id.split('.')[1] }}"
+      message: |
+        camera_with_flash: {{ entity_id.split('.')[1] }}
       data:
         file:
           path: |

--- a/scripts/notify_slack_about_camera.yaml
+++ b/scripts/notify_slack_about_camera.yaml
@@ -8,7 +8,7 @@ sequence:
   - service: notify.slack
     data_template:
       message: |
-        camera_with_flash: {{ entity_id.split('.')[1] }}
+        :camera_with_flash: {{ entity_id.split('.')[1] }}
       data:
         file:
           path: |

--- a/scripts/notify_slack_about_camera.yaml
+++ b/scripts/notify_slack_about_camera.yaml
@@ -4,11 +4,11 @@ sequence:
       entity_id: |
         {{ entity_id }}
       filename: |
-        /tmp/slack-{{ entity_id }}.png
+        /tmp/slack_{{ entity_id.split('.')[1] }}.png
   - service: notify.slack
     data_template:
-      message: ":camera_with_flash: {{ entity_id }}"
+      message: ":camera_with_flash: {{ entity_id.split('.')[1] }}"
       data:
         file:
           path: |
-            /tmp/slack-{{ entity_id }}.png
+            /tmp/slack_{{ entity_id.split('.')[1] }}.png

--- a/scripts/notify_slack_about_camera.yaml
+++ b/scripts/notify_slack_about_camera.yaml
@@ -1,0 +1,14 @@
+sequence:
+ - service: camera.snapshot
+   data_template:
+      entity_id: |
+        {{ entity_id }}
+      filename: |
+        /tmp/slack-{{ entity_id }}.png
+  - service: notify.slack
+    data_template:
+      message: ":camera_with_flash: {{ entity_id }}"
+      data:
+        file:
+          path: |
+            /tmp/slack-{{ entity_id }}.png

--- a/scripts/notify_slack_about_camera.yaml
+++ b/scripts/notify_slack_about_camera.yaml
@@ -1,6 +1,6 @@
 sequence:
- - service: camera.snapshot
-   data_template:
+  - service: camera.snapshot
+    data_template:
       entity_id: |
         {{ entity_id }}
       filename: |


### PR DESCRIPTION
The UI seems to reload camera cards frequently, which isn’t always compatible with my current internet situation. This PR sends them to slack on an interval so I can quickly soothe a tiny bit of anxiety by checking on things without using tons of data

- [x] Test manually
- [x] Figure out the right image URL to use, fix
- [x] Confirm they fire hourly
- [x] Tweak interval