### PR TITLE
Don't adjust garden light brightness

### DIFF
--- a/packages/lights.yaml
+++ b/packages/lights.yaml
@@ -197,6 +197,9 @@ homeassistant:
     light.wine_room:
       fixed_brightness: 102
 
+    light.kitchen_light:
+      ignore_brightness: true
+
 binary_sensor:
   - platform: template
     sensors:


### PR DESCRIPTION
Poor thing turns itself off if you include brightness data in a `light.turn_on` call, so let's avoid doing that.