### PR TITLE
Reduce frequency of invalid login alerts

### DIFF
--- a/ui-lovelace.yaml
+++ b/ui-lovelace.yaml
@@ -662,6 +662,7 @@ views:
             state: recording
         card:
           type: grid
+          square: false
           cards:
             - type: conditional
               conditions:

--- a/ui-lovelace.yaml
+++ b/ui-lovelace.yaml
@@ -4,15 +4,20 @@ views:
     icon: mdi:home
     theme: dark-mode
     cards:
-      - type: picture-glance
-        camera_image: camera.pergola
-        entities:
-          - input_select.mode
-          - alarm_control_panel.alarm
-          - lock.front_door
-          - binary_sensor.front_gate
-          - input_number.brightness
-          - vacuum.downstairs
+      - type: conditional
+        conditions:
+          - entity: camera.pergola
+            state: 'recording'
+        card:
+          type: picture-glance
+          camera_image: camera.pergola
+          entities:
+            - input_select.mode
+            - alarm_control_panel.alarm
+            - lock.front_door
+            - binary_sensor.front_gate
+            - input_number.brightness
+            - vacuum.downstairs
       - type: conditional
         conditions:
           - entity: input_select.mode

--- a/ui-lovelace.yaml
+++ b/ui-lovelace.yaml
@@ -7,7 +7,7 @@ views:
       - type: conditional
         conditions:
           - entity: camera.pergola
-            state: 'recording'
+            state: recording
         card:
           type: picture-glance
           camera_image: camera.pergola
@@ -381,14 +381,24 @@ views:
           - cover.gate
           - lock.garage
 
-      - type: picture-entity
-        show_name: false
-        show_state: false
-        entity: camera.front_door_person
-      - type: picture-entity
-        show_name: false
-        show_state: false
-        entity: camera.pergola_person
+      - type: conditional
+        conditions:
+          - entity: camera.front_door_person
+            state: active
+        card:
+          type: picture-entity
+          show_name: false
+          show_state: false
+          entity: camera.front_door_person
+      - type: conditional
+        conditions:
+          - entity: camera.pergola_person
+            state: active
+        card:
+          type: picture-entity
+          show_name: false
+          show_state: false
+          entity: camera.pergola_person
 
 
       - type: custom:custom-sonos-card
@@ -648,94 +658,101 @@ views:
     cards:
       - type: conditional
         conditions:
-          - entity: input_select.mode
-            state: Away
+          - entity: camera.pergola
+            state: recording
         card:
-          type: picture-entity
-          camera_view: live
-          show_name: false
-          show_state: false
-          entity: camera.great_room
+          type: grid
+          cards:
+            - type: conditional
+              conditions:
+                - entity: input_select.mode
+                  state: Away
+              card:
+                type: picture-entity
+                camera_view: live
+                show_name: false
+                show_state: false
+                entity: camera.great_room
 
-      - type: picture-entity
-        camera_view: live
-        show_name: false
-        show_state: false
-        entity: camera.front_yard_left
-      - type: picture-entity
-        camera_view: live
-        show_name: false
-        show_state: false
-        entity: camera.atrium
-      - type: picture-entity
-        camera_view: live
-        show_name: false
-        show_state: false
-        entity: camera.gate
-      - type: picture-entity
-        camera_view: live
-        show_name: false
-        show_state: false
-        entity: camera.garage
-      - type: picture-entity
-        camera_view: live
-        show_name: false
-        show_state: false
-        entity: camera.back_porch
-      - type: picture-entity
-        camera_view: live
-        show_name: false
-        show_state: false
-        entity: camera.ac
+            - type: picture-entity
+              camera_view: live
+              show_name: false
+              show_state: false
+              entity: camera.front_yard_left
+            - type: picture-entity
+              camera_view: live
+              show_name: false
+              show_state: false
+              entity: camera.atrium
+            - type: picture-entity
+              camera_view: live
+              show_name: false
+              show_state: false
+              entity: camera.gate
+            - type: picture-entity
+              camera_view: live
+              show_name: false
+              show_state: false
+              entity: camera.garage
+            - type: picture-entity
+              camera_view: live
+              show_name: false
+              show_state: false
+              entity: camera.back_porch
+            - type: picture-entity
+              camera_view: live
+              show_name: false
+              show_state: false
+              entity: camera.ac
 
-      - type: picture-entity
-        camera_view: live
-        show_name: false
-        show_state: false
-        entity: camera.front_door
-      - type: picture-entity
-        camera_view: live
-        show_name: false
-        show_state: false
-        entity: camera.pergola
-      - type: picture-entity
-        camera_view: live
-        show_name: false
-        show_state: false
-        entity: camera.roof_deck
+            - type: picture-entity
+              camera_view: live
+              show_name: false
+              show_state: false
+              entity: camera.front_door
+            - type: picture-entity
+              camera_view: live
+              show_name: false
+              show_state: false
+              entity: camera.pergola
+            - type: picture-entity
+              camera_view: live
+              show_name: false
+              show_state: false
+              entity: camera.roof_deck
 
-      - type: picture-entity
-        show_name: false
-        show_state: false
-        entity: camera.front_door_person
-      - type: picture-entity
-        show_name: false
-        show_state: false
-        entity: camera.pergola_person
-      - type: picture-entity
-        show_name: false
-        show_state: false
-        entity: camera.front_yard_left_person
-      - type: picture-entity
-        show_name: false
-        show_state: false
-        entity: camera.atrium_person
-      - type: picture-entity
-        show_name: false
-        show_state: false
-        entity: camera.back_porch_person
-      - type: picture-entity
-        show_name: false
-        show_state: false
-        entity: camera.gate_person
-      - type: picture-entity
-        show_name: false
-        show_state: false
-        entity: camera.garage_person
-      - type: picture-entity
-        show_name: false
-        show_state: false
-        entity: camera.ac_person
+            - type: picture-entity
+              show_name: false
+              show_state: false
+              entity: camera.front_door_person
+            - type: picture-entity
+              show_name: false
+              show_state: false
+              entity: camera.pergola_person
+            - type: picture-entity
+              show_name: false
+              show_state: false
+              entity: camera.front_yard_left_person
+            - type: picture-entity
+              show_name: false
+              show_state: false
+              entity: camera.atrium_person
+            - type: picture-entity
+              show_name: false
+              show_state: false
+              entity: camera.back_porch_person
+            - type: picture-entity
+              show_name: false
+              show_state: false
+              entity: camera.gate_person
+            - type: picture-entity
+              show_name: false
+              show_state: false
+              entity: camera.garage_person
+            - type: picture-entity
+              show_name: false
+              show_state: false
+              entity: camera.ac_person
 
       - type: custom:auto-entities
         show_header_toggle: false


### PR DESCRIPTION
From https://github.com/home-assistant/core/issues/23055#issuecomment-1029720833:

> I'm by no means a professional programmer but from reading online and in this topic my guess is that by doing it this way a connection to home assistant is forced to retrieve the state of the helper before the camera lovelace card can give the login attempt error.

✨ 😍 