### PR TITLE
add esphome apple device sensor

### DIFF
--- a/packages/occupancy.yaml
+++ b/packages/occupancy.yaml
@@ -211,8 +211,9 @@ binary_sensor:
           {{
             states('cover.garage') == 'open' or
             states('lock.garage') == 'unlocked' or
-            float(states('sensor.garage_person_count'), default=0) > 0  or
-            states.sensor.garage_person_count.last_changed > (now() - timedelta(minutes=10))
+            float(states('sensor.garage_person_count'), default=0) > 0 or
+            states.sensor.garage_person_count.last_changed > (now() - timedelta(minutes=10)) or
+            is_state('binary_sensor.garage_apple_device_detected', 'on')
           }}
 
       back_porch_occupancy:


### PR DESCRIPTION
See https://github.com/dalehumby/ESPHome-Apple-Watch-detection/issues/4#issuecomment-918409202 for the current esphome config for this sensor, which aims to detect active iOS or MacOS devices and unlocked Apple Watches. Hoping to use this as a presence sensor in some areas where neither PIR nor video object detection are reliable.