### PR TITLE
Log more info about switches

### DIFF
--- a/logger.yaml
+++ b/logger.yaml
@@ -7,7 +7,7 @@ logs:
   homeassistant.components.media_player: warn
   homeassistant.components.sensor: warn
   homeassistant.components.shell_command: debug
-  homeassistant.components.switch: warn
+  homeassistant.components.switch: info
   packages.ack: debug
   packages.auto_lock: debug
   packages.house_speakers: debug


### PR DESCRIPTION
Trying to track down why the switches created from multiple custom programs on a Bhyve device end up with identical names