### PR TITLE
Workday YAML configuration is being removed

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
 concurrency:
-  group: cd-${{ github.event.pull_request.number }}-${{ github.event_name }}-${{ github.event.label.name }}
+  group: cd-${{ github.event.pull_request.number }}-${{ github.event_name }}
   cancel-in-progress: true
 jobs:
   # debug:

--- a/packages/shades.yaml
+++ b/packages/shades.yaml
@@ -1,11 +1,3 @@
-binary_sensor:
-  - platform: workday
-    country: US
-    workdays: [mon, tue, wed, thu, fri]
-    excludes: [sat, sun, holiday]
-    remove_holidays:
-      - "Washington's Birthday"
-
 cover:
   - platform: group
     name: Shades

--- a/ui-lovelace.yaml
+++ b/ui-lovelace.yaml
@@ -1727,6 +1727,7 @@ views:
           - sensor.current_version
           - sensor.config_sha
           - sensor.latest_deployment_sha
+          - automation.deploy_latest_deployment
       - type: custom:auto-entities
         show_empty: false
         sort:


### PR DESCRIPTION
 This stops working in version 2023.7.0. Please address before upgrading.

Your existing YAML configuration has been imported into the UI automatically.

Remove the Workday YAML configuration from your configuration.yaml file and restart Home Assistant to fix this issue.