### PR TITLE
Enhance lounge UI and update entity references

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,0 +1,3 @@
+HASS_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJiMzAwMjk2YTEzNDc0NjU0OGM0MGE4ZDhhNWZkYzUwMyIsImlhdCI6MTc0MjIxMTk4OSwiZXhwIjoyMDU3NTcxOTg5fQ.4xry4gIw2ZQoiYa7um5pLpkt0n4fytRHzreOxn4l9uI
+HASS_URL=https://home.jnewland.com
+

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@
 .nfs*
 home-assistant.log.*
 automations.yaml
+env.dev
+template.jinja

--- a/groups/outdoor_speakers.yaml
+++ b/groups/outdoor_speakers.yaml
@@ -1,7 +1,0 @@
-name: Outdoor speakers
-entities:
-- media_player.record_cabinet_output_atrium
-- media_player.record_cabinet_output_patio
-- media_player.record_cabinet_output_back_porch
-- media_player.record_cabinet_output_pergola
-- media_player.record_cabinet_output_front_porch

--- a/lights/bedroom.yaml
+++ b/lights/bedroom.yaml
@@ -7,6 +7,6 @@ entities:
   - light.bedroom_closet
   - light.bedroom_nook
   - light.bedroom_windows
-  - light.bedside_lamp
+  # - light.bedside_lamp
   - light.bedside_table
   - light.bedroom_patio

--- a/packages/laundry.yaml
+++ b/packages/laundry.yaml
@@ -60,7 +60,7 @@ binary_sensor:
         value_template: |
           {{
             states('sensor.laundry_electric_consumption_w') != 'unknown' and
-            is_state('binary_sensor.laundry', 'off') and
+            is_state('binary_sensor.laundry_power', 'off') and
             float(states('sensor.laundry_electric_consumption_w'), default=0) > 0 and
             float(states('sensor.laundry_electric_consumption_w'), default=0) < 10
           }}

--- a/packages/lights.yaml
+++ b/packages/lights.yaml
@@ -51,7 +51,7 @@ homeassistant:
       haunt: light.bookshelf_right
     binary_sensor.record_cabinet_playing:
       trigger_service: script.pulse_record_cabinet_lights
-    binary_sensor.bookshelf_camera_in_use:
+    binary_sensor.bigmac_camera_in_use:
       trigger_service: script.red_record_cabinet_lights
       trigger_service_off: script.reset_record_cabinet_lights
     binary_sensor.spacebook_camera_in_use:

--- a/script/template
+++ b/script/template
@@ -1,4 +1,13 @@
 #!/bin/bash
+if [ -f .env.dev ]; then
+  # use xargs to load all env vars from env.dev
+  export $(cat .env.dev | xargs)
+  echo "Loaded env vars from .env.dev"
+else
+  echo "No .env.dev file found"
+  exit 1
+fi
+
 JSON="$(jq -a --raw-output --arg value "$(</dev/stdin)" '.["template"]=$value' <<< '{}')"
 curl -sS \
   -H "Authorization: Bearer $HASS_TOKEN" \

--- a/scripts/mode_reading.yaml
+++ b/scripts/mode_reading.yaml
@@ -20,7 +20,7 @@ sequence:
       entity_id:
         - light.bedroom_chandelier
         - light.chandelier_lamp
-        - light.bedside_lamp
+        # - light.bedside_lamp
         - light.bedside_table
         - light.bedroom_nook
         - light.bedroom_patio

--- a/ui-lovelace/000-home.yaml
+++ b/ui-lovelace/000-home.yaml
@@ -8,7 +8,7 @@ cards:
       - input_select.mode
       - alarm_control_panel.alarm
       - lock.front_door
-      # - binary_sensor.front_gate_access_control_window_door_is_open
+      - binary_sensor.front_gate_window_door_is_open
       - input_number.brightness
       - vacuum.downstairs
       - automation.notify_when_person_detected_in_front_yard

--- a/ui-lovelace/004-lounge.yaml
+++ b/ui-lovelace/004-lounge.yaml
@@ -16,6 +16,31 @@ cards:
       entity: sensor.lounge_air_temperature
       hours_to_show: 36
       detail: 2
+
+  - type: media-control
+    entity: media_player.lg_webos_tv_d510
+  - type: media-control
+    entity: media_player.lounge
+  - type: media-control
+    entity: media_player.lounge_surround
+  - type: media-control
+    entity: media_player.lounge_channels
+  - type: entities
+    title: bath
+    entities:
+      - light.guest_hall_overhead
+      - light.guest_bath_mirror
+      - light.guest_shower
+      - binary_sensor.guest_bath_home_security_motion_detection
+      - binary_sensor.guest_hall_home_security_motion_detection
+      - sensor.guest_bath_air_temperature
+      - switch.guest_bath_fan
+    footer:
+      type: graph
+      entity: sensor.guest_bath_air_temperature
+      hours_to_show: 36
+      detail: 2
+
   - type: custom:auto-entities
     entities:
       - automation.lounge_fan_auto_mode
@@ -58,27 +83,3 @@ cards:
               }
           -}},
         {%- endfor -%}
-
-  - type: media-control
-    entity: media_player.lg_webos_tv_d510
-  - type: media-control
-    entity: media_player.lounge
-  - type: media-control
-    entity: media_player.lounge_surround
-  - type: media-control
-    entity: media_player.lounge_channels
-  - type: entities
-    title: bath
-    entities:
-      - light.guest_hall_overhead
-      - light.guest_bath_mirror
-      - light.guest_shower
-      - binary_sensor.guest_bath_home_security_motion_detection
-      - binary_sensor.guest_hall_home_security_motion_detection
-      - sensor.guest_bath_air_temperature
-      - switch.guest_bath_fan
-    footer:
-      type: graph
-      entity: sensor.guest_bath_air_temperature
-      hours_to_show: 36
-      detail: 2

--- a/ui-lovelace/005-music-room.yaml
+++ b/ui-lovelace/005-music-room.yaml
@@ -12,9 +12,9 @@ cards:
       - binary_sensor.music_room_home_security_motion_detection
       - binary_sensor.music_room_window
       - sensor.music_room_air_temperature
-      - binary_sensor.bookshelf_active
-      - binary_sensor.bookshelf_camera_in_use
-      - sensor.bookshelf_frontmost_app
+      - binary_sensor.bigmac_active
+      - binary_sensor.bigmac_camera_in_use
+      - sensor.bigmac_frontmost_app
     footer:
       type: graph
       entity: sensor.music_room_air_temperature

--- a/ui-lovelace/007-upstairs.yaml
+++ b/ui-lovelace/007-upstairs.yaml
@@ -8,7 +8,7 @@ cards:
       - light.bedroom_overhead
       - light.bedroom_nook
       - light.bedroom_windows
-      - light.bedside_lamp
+      # - light.bedside_lamp
       - light.bedside_table
       - light.chandelier_lamp
       - light.bedroom_patio

--- a/ui-lovelace/009-outdoor.yaml
+++ b/ui-lovelace/009-outdoor.yaml
@@ -12,7 +12,7 @@ cards:
   - type: entities
     title: atrium
     entities:
-      - switch.atrium_fan
+      # - switch.atrium_fan
       - light.bamboo
       - light.atrium
       - light.atrium_door
@@ -29,7 +29,7 @@ cards:
     entities:
       - light.front_porch
       - light.front_door
-      - binary_sensor.front_gate_access_control_window_door_is_open
+      - binary_sensor.front_gate_window_door_is_open
   - type: entities
     title: patio
     entities:
@@ -42,7 +42,7 @@ cards:
       - switch.pergola_overhead
   - type: entities
     entities:
-      - binary_sensor.front_gate_access_control_window_door_is_open
+      - binary_sensor.front_gate_window_door_is_open
       - cover.garage
       - cover.gate
   - type: entities


### PR DESCRIPTION
Introduce media control and bath entity cards to the lounge UI, while renaming the bookshelf camera binary sensor to bigmac and updating related references in the music room UI. Clean up configurations by removing outdoor speakers and commenting out bedside lamp references in the bedroom. Fix binary sensor state references in the laundry configuration.