### PR TITLE
Update package_unavailable_entities.yaml

### DIFF
--- a/packages/package_unavailable_entities.yaml
+++ b/packages/package_unavailable_entities.yaml
@@ -24,11 +24,12 @@ template:
             {% if state_attr('group.ignored_unavailable_entities','entity_id') != none %}
               {% set thirty_minutes = 1800 %}
               {% set ignore_ts = (now().timestamp() - thirty_minutes)|as_datetime %}
-              {% set entities = states|rejectattr('domain','in',['group','button','scene'])|selectattr('state','in',['unavailable','unknown','none'])|list %}
+              {% set entities = states|rejectattr('domain','in',['group','button','scene'])|selectattr('state','in',['unavailable'])|list %}
               {% set buttons = states.button|selectattr('state','eq','unavailable')|list %}
               {{ (entities + buttons)
                 |rejectattr('entity_id', 'in', state_attr('group.ignored_unavailable_entities','entity_id'))
                 |rejectattr('entity_id', 'in', integration_entities('sonos'))
+                |rejectattr('entity_id', 'in', integration_entities('xiaomi_ble'))
                 |rejectattr('entity_id', 'in', integration_entities('unifi'))
                 |rejectattr('entity_id', 'in', integration_entities('unifiprotect'))
                 |rejectattr('last_changed','ge',ignore_ts)

--- a/packages/package_unavailable_entities.yaml
+++ b/packages/package_unavailable_entities.yaml
@@ -22,9 +22,9 @@ template:
         attributes:
           entity_id: >
             {% if state_attr('group.ignored_unavailable_entities','entity_id') != none %}
-              {% set thirty_minutes = 1800 %}
-              {% set ignore_ts = (now().timestamp() - thirty_minutes)|as_datetime %}
-              {% set entities = states|rejectattr('domain','in',['group','button','scene'])|selectattr('state','in',['unavailable'])|list %}
+              {% set timeout = 600 %}
+              {% set ignore_ts = (now().timestamp() - timeout)|as_datetime %}
+              {% set entities = states|rejectattr('domain','in',['group','button','scene'])|selectattr('state','eq','unavailable')|list %}
               {% set buttons = states.button|selectattr('state','eq','unavailable')|list %}
               {{ (entities + buttons)
                 |rejectattr('entity_id', 'in', state_attr('group.ignored_unavailable_entities','entity_id'))

--- a/packages/package_unavailable_entities.yaml
+++ b/packages/package_unavailable_entities.yaml
@@ -21,17 +21,22 @@ template:
           {% endif %}
         attributes:
           entity_id: >
-            {% if state_attr('group.ignored_unavailable_entities','entity_id') != none %}
+            {% set ignored = state_attr('group.ignored_unavailable_entities','entity_id') %}
+            {% if ignored != none %}
+              {% set sonos = integration_entities('sonos') %}
+              {% set xiaomi_ble = integration_entities('xiaomi_ble') %}
+              {% set unifi = integration_entities('unifi') %}
+              {% set unifiprotect = integration_entities('unifiprotect') %}
               {% set timeout = 600 %}
               {% set ignore_ts = (now().timestamp() - timeout)|as_datetime %}
               {% set entities = states|rejectattr('domain','in',['group','button','scene'])|selectattr('state','eq','unavailable')|list %}
               {% set buttons = states.button|selectattr('state','eq','unavailable')|list %}
               {{ (entities + buttons)
-                |rejectattr('entity_id', 'in', state_attr('group.ignored_unavailable_entities','entity_id'))
-                |rejectattr('entity_id', 'in', integration_entities('sonos'))
-                |rejectattr('entity_id', 'in', integration_entities('xiaomi_ble'))
-                |rejectattr('entity_id', 'in', integration_entities('unifi'))
-                |rejectattr('entity_id', 'in', integration_entities('unifiprotect'))
+                |rejectattr('entity_id', 'in', ignored)
+                |rejectattr('entity_id', 'in', sonos)
+                |rejectattr('entity_id', 'in', xiaomi_ble)
+                |rejectattr('entity_id', 'in', unifi)
+                |rejectattr('entity_id', 'in', unifiprotect)
                 |rejectattr('last_changed','ge',ignore_ts)
                 |rejectattr('entity_id','search','_channels')
                 |rejectattr('entity_id','search','webos_tv')

--- a/packages/package_unavailable_entities.yaml
+++ b/packages/package_unavailable_entities.yaml
@@ -29,6 +29,8 @@ template:
               {{ (entities + buttons)
                 |rejectattr('entity_id', 'in', state_attr('group.ignored_unavailable_entities','entity_id'))
                 |rejectattr('entity_id', 'in', integration_entities('sonos'))
+                |rejectattr('entity_id', 'in', integration_entities('unifi'))
+                |rejectattr('entity_id', 'in', integration_entities('unifiprotect'))
                 |rejectattr('last_changed','ge',ignore_ts)
                 |rejectattr('entity_id','search','_channels')
                 |rejectattr('entity_id','search','webos_tv')


### PR DESCRIPTION
This pull request includes changes to the `packages/package_unavailable_entities.yaml` file to further filter out specific integration entities. 

Filtering of additional integration entities:

* [`packages/package_unavailable_entities.yaml`](diffhunk://#diff-4d8a3b6e4c260330b83203d9cc92f4a2551cb4b510b1764b87d9d1a86f73094cR32-R33): Added filtering for `unifi` and `unifiprotect` integration entities in the template.