### PR TITLE
Remove bamboo light and update configurations for maple and pecan lights

### DIFF
--- a/customize/lights.yaml
+++ b/customize/lights.yaml
@@ -4,10 +4,7 @@ light.front_door:
   icon: mdi:outdoor-lamp
 light.front_porch:
   icon: mdi:ceiling-light
-light.bamboo:
-  icon: mdi:wall-sconce-flat-variant
 light.atrium:
   icon: mdi:ceiling-light
 light.atrium_door:
   icon: mdi:outdoor-lamp
- 

--- a/lights/outdoor_mood.yaml
+++ b/lights/outdoor_mood.yaml
@@ -2,7 +2,6 @@ platform: group
 name: outdoor mood
 entities:
   - light.pergola_pendants
-  - light.bamboo
   - light.gate
   - light.wine_room
   - light.patio

--- a/lights/outdoor_mood.yaml
+++ b/lights/outdoor_mood.yaml
@@ -1,7 +1,6 @@
 platform: group
 name: outdoor mood
 entities:
-  - light.pergola_pendants
   - light.gate
   - light.wine_room
   - light.patio
@@ -9,3 +8,5 @@ entities:
   - light.lounge_fence
   - light.roof_deck_couch
   - light.oak
+  - light.maple
+  - light.pecan

--- a/packages/lights.yaml
+++ b/packages/lights.yaml
@@ -88,9 +88,6 @@ homeassistant:
     light.kitchen_cabinets:
       notify_action: duck
 
-    light.pergola_pendants:
-      fixed_brightness: 103
-
     light.bedside_table_white:
       ignore_brightness: true
     light.bedside_table_red:

--- a/packages/lights.yaml
+++ b/packages/lights.yaml
@@ -69,10 +69,6 @@ homeassistant:
     light.atrium:
       notify_action: duck
       fixed_brightness: 64
-    light.bamboo:
-      notify_action: duck
-      fixed_brightness: 127
-      fixed_color_temp: 396
     light.front_porch:
       fixed_brightness: 255
 

--- a/ui-lovelace/008-grill.yaml
+++ b/ui-lovelace/008-grill.yaml
@@ -52,7 +52,8 @@ cards:
   - type: entities
     title: pergola
     entities:
-      - light.pergola_pendants
+      - light.maple
+      - light.pecan
       - switch.pergola_overhead
   - type: markdown
     content: |

--- a/ui-lovelace/009-outdoor.yaml
+++ b/ui-lovelace/009-outdoor.yaml
@@ -28,6 +28,9 @@ cards:
     entities:
       - light.front_porch
       - light.front_door
+      - light.oak
+      - light.maple
+      - light.pecan
       - binary_sensor.front_gate_window_door_is_open
   - type: entities
     title: patio
@@ -37,7 +40,8 @@ cards:
   - type: entities
     title: pergola
     entities:
-      - light.pergola_pendants
+      - light.maple
+      - light.pecan
       - switch.pergola_overhead
   - type: entities
     entities:

--- a/ui-lovelace/009-outdoor.yaml
+++ b/ui-lovelace/009-outdoor.yaml
@@ -13,7 +13,6 @@ cards:
     title: atrium
     entities:
       # - switch.atrium_fan
-      - light.bamboo
       - light.atrium
       - light.atrium_door
       - light.garage_door


### PR DESCRIPTION
Eliminate references to the bamboo light and replace pergola_pendants with maple and pecan in various configurations.