### PR TITLE
Use DNS aliases for channels integration

### DIFF
--- a/media_player.yaml
+++ b/media_player.yaml
@@ -1,12 +1,12 @@
 - platform: channels
   name: music room channels
-  host: music-room
+  host: music-room-channels
 - platform: channels
   name: lounge channels
-  host: lounge
+  host: lounge-channels
 - platform: channels
   name: bedroom channels
-  host: bedroom
+  host: bedroom-channels
 - platform: channels
   name: garage channels
-  host: garage-tv
+  host: garage-channels

--- a/packages/channels.yaml
+++ b/packages/channels.yaml
@@ -1,4 +1,3 @@
-
 script:
   change_all_to_camera:
     sequence:
@@ -36,28 +35,28 @@ script:
     sequence:
       - service: shell_command.notify_channels
         data:
-          host: music-room
+          host: music-room-channels
           title: |
             {{ title | default("") }}
           message: |
             {{ message | default("") }}
       - service: shell_command.notify_channels
         data:
-          host: lounge
+          host: lounge-channels
           title: |
             {{ title | default("") }}
           message: |
             {{ message | default("") }}
       - service: shell_command.notify_channels
         data:
-          host: bedroom
+          host: bedroom-channels
           title: |
             {{ title | default("") }}
           message: |
             {{ message | default("") }}
       - service: shell_command.notify_channels
         data:
-          host: garage-tv
+          host: garage-channels
           title: |
             {{ title | default("") }}
           message: |


### PR DESCRIPTION
Update channel host configurations to utilize DNS aliases for improved integration and consistency across the platform.