### PR TITLE
Improve deployment sensor efficiency

### DIFF
--- a/packages/deploy.yaml
+++ b/packages/deploy.yaml
@@ -12,7 +12,7 @@ command_line:
   - sensor:
       name: Latest Deployment SHA
       unique_id: 1f3312ec-3976-43a6-afdc-88720472a96d
-      scan_interval: 90
+      scan_interval: 180
       command: |
         curl \
         -s \
@@ -23,7 +23,7 @@ command_line:
   - sensor:
       name: Latest Deployment Tree SHA
       unique_id: b37c6289-fa64-437c-acc4-bfedab3dcd71
-      scan_interval: 90
+      scan_interval: 180
       command: |
         COMMIT=$(curl -s \
           "https://api.github.com/repos/jnewland/ha-config/deployments?environment=production" | \

--- a/packages/deploy.yaml
+++ b/packages/deploy.yaml
@@ -14,27 +14,25 @@ command_line:
       unique_id: 1f3312ec-3976-43a6-afdc-88720472a96d
       scan_interval: 180
       command: |
-        curl \
-        -s \
-        -H "Accept: application/vnd.github.ant-man-preview+json" \
-        "https://api.github.com/repos/jnewland/ha-config/deployments?environment=production" | \
-        jq -r '.[0].sha // empty'
-
-  - sensor:
-      name: Latest Deployment Tree SHA
-      unique_id: b37c6289-fa64-437c-acc4-bfedab3dcd71
-      scan_interval: 180
-      command: |
-        COMMIT=$(curl -s \
+        SHA=$(curl -s \
+          -H "Accept: application/vnd.github.ant-man-preview+json" \
           "https://api.github.com/repos/jnewland/ha-config/deployments?environment=production" | \
           jq -r '.[0].sha // empty') && \
-        [ -n "$COMMIT" ] && \
-        curl -s \
-          "https://api.github.com/repos/jnewland/ha-config/commits/$COMMIT" | \
-          jq -r '.commit.tree.sha // empty'
+        [ -n "$SHA" ] && \
+        TREE=$(curl -s \
+          "https://api.github.com/repos/jnewland/ha-config/commits/$SHA" | \
+          jq -r '.commit.tree.sha // empty') && \
+        jq -rn --arg sha "$SHA" --arg tree "$TREE" '{"sha":$sha,"tree":$tree}'
+      value_template: "{{ value_json.sha }}"
+      json_attributes:
+        - tree
 
 template:
   - sensor:
+      - name: Latest Deployment Tree SHA
+        unique_id: b37c6289-fa64-437c-acc4-bfedab3dcd71
+        state: "{{ state_attr('sensor.latest_deployment_sha', 'tree') }}"
+
       - name: Deploy Status
         unique_id: bad5adca-c78c-406e-8f9a-8723995bc5b7
         state: >-


### PR DESCRIPTION
Increase the scan interval for the latest deployment sensor and streamline the command to fetch the latest deployment tree SHA, reducing unnecessary requests. Add a new sensor to capture the deployment tree SHA.